### PR TITLE
feat(store): Add a minified version of a state management store

### DIFF
--- a/store/store.errors.ts
+++ b/store/store.errors.ts
@@ -1,0 +1,12 @@
+import { Actions } from './store.types'
+
+export class MissingActionError extends Error {
+  constructor(action: string, actions: Actions) {
+    super(`Can't find '${action}' action in the defined actions:
+    defined actions names are: ${Object.keys(actions).map(
+      action => `'${action}'`
+    )}
+    `)
+    this.name = this.constructor.name
+  }
+}

--- a/store/store.tests.ts
+++ b/store/store.tests.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect } from '../utils/test'
+
+import { MissingActionError } from './store.errors'
+import Store from './store'
+
+describe('GIVEN: a generic store', () => {
+  describe('WHEN: it is in the initial state', () => {
+    const counterInitialState = 0
+    const counterStore = new Store(
+      { n: counterInitialState },
+      {
+        actions: {
+          increment: state => state.n++,
+        },
+      }
+    )
+    it('THEN: its values should be the initial ones', () => {
+      // arrange
+      const expected = 0
+
+      // assert
+      expect(counterStore.state.n).toEqual(expected)
+    })
+    it('AND: its history should be empty', () => {
+      expect(counterStore.history).toBeEmpty()
+    })
+  })
+  describe('WHEN: it is in whichever state', () => {
+    const counterStore = new Store(
+      { n: 288 },
+      {
+        actions: {
+          increment: state => state.n++,
+        },
+      }
+    )
+
+    it('THEN: its values can be modified dispatching actions', () => {
+      // arrange
+      const expected = 290
+
+      // act
+      counterStore.dispatch('increment')
+      counterStore.dispatch('increment')
+
+      // assert
+      expect(counterStore.state.n).toEqual(expected)
+    })
+    it('AND: its history is modified accordingly', () => {
+      // arrange
+      const expected = ['increment', 'increment']
+
+      // assert
+      expected.every(expectedAction =>
+        expect(counterStore.history).toContain(expectedAction)
+      )
+      expect(counterStore.history.length).toEqual(2)
+    })
+    it('AND: it throws a MissingActionError when dispatching non existing actions', () => {
+      // act
+      try {
+        counterStore.dispatch('this should blow up')
+      } catch (error) {
+        expect(error instanceof MissingActionError).toBeTruthy()
+      }
+
+      // assert
+      expect(counterStore.history).toNotContain('this should blow up')
+    })
+  })
+})
+
+describe('GIVEN: a store with the observer pattern', () => {
+  const broadcastStore = new Store(
+    {},
+    {
+      actions: {
+        broadcastMessage: (state, ..._messages) => state,
+      },
+    }
+  )
+  let counter = 0
+
+  const adderWorker = (actionName: string, message: string) => {
+    if (message === 'addOne') counter++
+  }
+
+  const resetStore = () => {
+    broadcastStore.listeners = []
+    broadcastStore.history = []
+  }
+
+  describe('WHEN: there are no listeners', () => {
+    resetStore()
+
+    it('THEN: the listeners list is empty', () => {
+      // assert
+      expect(broadcastStore.listeners).toBeEmpty()
+      expect(broadcastStore.history).toBeEmpty()
+      expect(counter).toEqual(0)
+    })
+  })
+
+  describe('WHEN: there are no listeners AND we dispatch an action', () => {
+    resetStore()
+
+    it('THEN: the action is added, but no listener acts', () => {
+      // act
+      broadcastStore.dispatch('broadcastMessage', 'addOne')
+
+      // assert
+      expect(broadcastStore.listeners).toBeEmpty()
+      expect(broadcastStore.history).toContain('broadcastMessage')
+      expect(broadcastStore.history.length).toEqual(1)
+      expect(counter).toEqual(0)
+    })
+  })
+
+  describe('WHEN: there is a listener AND we dispatch an action', () => {
+
+    it('THEN: if the action matches what a listener expects, that listener acts', () => {
+      // assert
+      resetStore()
+      expect(broadcastStore.listeners).toBeEmpty()
+      expect(broadcastStore.history).toBeEmpty()
+
+      // act
+      broadcastStore.subscribe(adderWorker)
+      broadcastStore.dispatch('broadcastMessage', 'addOne')
+
+      // assert
+      expect(broadcastStore.listeners.length).toEqual(1)
+      expect(broadcastStore.history.length).toEqual(1)
+      expect(counter).toEqual(1)
+    })
+
+    it('THEN: if the action does not match what a listener expects, no listener acts', () => {
+      // arrange
+      resetStore()
+      counter = 0
+      broadcastStore.subscribe(adderWorker)
+
+      // assert
+      expect(broadcastStore.listeners.length).toEqual(1)
+      expect(broadcastStore.history).toBeEmpty()
+
+      // act
+      broadcastStore.dispatch('broadcastMessage', 'noListener')
+
+      // assert
+      expect(broadcastStore.listeners.length).toEqual(1)
+      expect(broadcastStore.history.length).toEqual(1)
+      expect(counter).toEqual(0)
+    })
+  })
+
+  describe('WHEN: there is a listener AND we unsubscribe it before dispatching its matching action', () => {
+
+    it('THEN: there are no listeners that can act', () => {
+      // arrange 
+      resetStore()
+      counter = 0
+      broadcastStore.subscribe(adderWorker)
+
+      // assert
+      expect(broadcastStore.listeners.length).toEqual(1)
+      expect(broadcastStore.history).toBeEmpty()
+
+      // act
+      broadcastStore.unsubscribe(adderWorker)
+      broadcastStore.dispatch('broadcastMessage', 'addOne')
+
+      // assert
+      expect(broadcastStore.listeners).toBeEmpty()
+      expect(broadcastStore.history.length).toEqual(1)
+      expect(counter).toEqual(0)
+    })
+  })
+})

--- a/store/store.ts
+++ b/store/store.ts
@@ -1,0 +1,45 @@
+import { Actions } from './store.types'
+import { Listener } from './store.types'
+import { Listeners } from './store.types'
+import { State } from './store.types'
+import { MissingActionError } from './store.errors'
+
+class Store {
+  state: State
+  actions: Actions
+  listeners: Listeners
+  history: Array<string>
+  constructor(initialState: State, { actions }: { actions: Actions }) {
+    this.state = initialState
+    this.actions = actions
+    this.listeners = []
+    this.history = []
+    /*
+      Another option instead of pasing the state to the actions is:
+      bind the Store to the actions so they have access to the store through 'this'
+      for (const action in this.actions) {
+        this.actions[action] = this.actions[action].bind(this)
+      }
+      and then define the actions as:
+      { increment: function() { this.state.counter++ } }
+    */
+  }
+  dispatch(actionName: string, ...args: any): any {
+    if (!(actionName in this.actions)) {
+      throw new MissingActionError(actionName, this.actions)
+    }
+    const toBeReturned = this.actions[actionName](this.state, ...args)
+    this.history.push(actionName)
+    this.listeners.forEach(listener => listener(actionName, ...args))
+    return toBeReturned
+  }
+  subscribe(listener: Listener) {
+    if (!this.listeners.includes(listener)) this.listeners.push(listener)
+  }
+  unsubscribe(listener: Listener) {
+    const indexOfListener = this.listeners.indexOf(listener)
+    if (indexOfListener >= 0) this.listeners.splice(indexOfListener, 1)
+  }
+}
+
+export default Store

--- a/store/store.types.ts
+++ b/store/store.types.ts
@@ -1,0 +1,9 @@
+export type State = Record<string, any>
+
+export type Action = (arg0: State, ...args: any) => void
+
+export type Actions = Record<string, Action>
+
+export type Listener = (arg0: string, ...args: any) => any
+
+export type Listeners = Array<Listener>


### PR DESCRIPTION
It works by mutating directly the state inside the actions, no needed mutations, commit fn or reducers. It's heavily opinionated. It supports the observer pattern.